### PR TITLE
Only publish when hardware is active

### DIFF
--- a/thruster_hardware/include/thruster_hardware/thruster_hardware.hpp
+++ b/thruster_hardware/include/thruster_hardware/thruster_hardware.hpp
@@ -77,6 +77,10 @@ private:
   std::shared_ptr<rclcpp::Client<rcl_interfaces::srv::SetParameters>> set_params_client_;
   std::unordered_map<std::string, ThrusterConfig> thruster_configs_;
 
+  // the write loop run regardless of whether or not the hardware is active
+  // so we need to keep track of this to ensure that we only send commands when the hardware is active
+  bool is_active_{false};
+
   int max_retries_;
   rclcpp::Logger logger_{rclcpp::get_logger("ardusub_thruster_hardware")};
 };

--- a/thruster_hardware/src/thruster_hardware.cpp
+++ b/thruster_hardware/src/thruster_hardware.cpp
@@ -169,6 +169,9 @@ auto ThrusterHardware::on_activate(const rclcpp_lifecycle::State & /*previous_st
       // Stop the thrusters before switching to an external controller
       stop_thrusters();
 
+      // start sending rc override messages from the write loop
+      is_active_ = true;
+
       return hardware_interface::CallbackReturn::SUCCESS;
     }
   }
@@ -179,12 +182,18 @@ auto ThrusterHardware::on_activate(const rclcpp_lifecycle::State & /*previous_st
     "plugin is fully running and configured.",
     max_retries_);
 
+  // don't send rc override messages if we failed to set the parameters
+  is_active_ = false;
+
   return hardware_interface::CallbackReturn::ERROR;
 }
 
 auto ThrusterHardware::on_deactivate(const rclcpp_lifecycle::State & /*previous_state*/)
   -> hardware_interface::CallbackReturn
 {
+  // stop sending rc override messages from the write loop
+  is_active_ = false;
+
   // stop the thrusters before switching out of passthrough mode
   stop_thrusters();
 
@@ -237,7 +246,7 @@ auto ThrusterHardware::read(const rclcpp::Time & /*time*/, const rclcpp::Duratio
 auto ThrusterHardware::write(const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
   -> hardware_interface::return_type
 {
-  if (rt_override_rc_pub_ && rt_override_rc_pub_->trylock()) {
+  if (rt_override_rc_pub_ && rt_override_rc_pub_->trylock() && is_active_) {
     for (const auto & [name, desc] : joint_command_interfaces_) {
       const auto command = get_command(name);
       if (std::isnan(command)) {

--- a/thruster_hardware/src/thruster_hardware.cpp
+++ b/thruster_hardware/src/thruster_hardware.cpp
@@ -246,7 +246,11 @@ auto ThrusterHardware::read(const rclcpp::Time & /*time*/, const rclcpp::Duratio
 auto ThrusterHardware::write(const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
   -> hardware_interface::return_type
 {
-  if (rt_override_rc_pub_ && rt_override_rc_pub_->trylock() && is_active_) {
+  if (!is_active_) {
+    return hardware_interface::return_type::OK;
+  }
+
+  if (rt_override_rc_pub_ && rt_override_rc_pub_->trylock()) {
     for (const auto & [name, desc] : joint_command_interfaces_) {
       const auto command = get_command(name);
       if (std::isnan(command)) {


### PR DESCRIPTION
## Changes Made

The thruster hardware write loop will execute regardless of whether or not the hardware is active. This PR adds control flow to ensure that override messages are sent only when the thruster hardware is active

## Testing

Testing done on the BlueROV
